### PR TITLE
Add audio preview player to Crucial Tracks entries

### DIFF
--- a/cc.otavio.tracks.crucial/plugin-config.json
+++ b/cc.otavio.tracks.crucial/plugin-config.json
@@ -8,5 +8,5 @@
   "site": "https://app.crucialtracks.org",
   "service_name": "Crucial Tracks",
   "item_style": "post",
-  "version": 4
+  "version": 5
 }

--- a/cc.otavio.tracks.crucial/plugin.js
+++ b/cc.otavio.tracks.crucial/plugin.js
@@ -78,8 +78,22 @@ function createItemFromEntry(entry) {
   item.body = buildItemBody(songDetails, entry.content_html);
   item.author = createIdentity(author);
 
+  const attachments = [];
+
   if (songDetails.artwork_url) {
-    item.attachments = [createMediaAttachment(songDetails.artwork_url)];
+    attachments.push(
+      createMediaAttachment(songDetails.artwork_url)
+    );
+  }
+
+  if (songDetails.preview_url) {
+    attachments.push(
+      createAudioAttachment(songDetails.preview_url, songDetails)
+    );
+  }
+
+  if (attachments.length > 0) {
+    item.attachments = attachments;
   }
 
   return item;
@@ -157,6 +171,23 @@ function createMediaAttachment(url) {
 
   attachment.mimeType = "image/jpeg";
   attachment.aspectSize = { width: 600, height: 600 };
+
+  return attachment;
+}
+
+/**
+ * Creates a media attachment for the 30-second audio preview
+ * @param {string} url - The preview audio URL
+ * @param {Object} songDetails - The song details for the accessibility label
+ * @returns {Object} Media attachment object
+ */
+function createAudioAttachment(url, songDetails) {
+  const attachment = MediaAttachment.createWithUrl(url);
+  const artist = songDetails.artist || "Unknown Artist";
+  const song = songDetails.song || "Unknown Track";
+
+  attachment.mimeType = "audio";
+  attachment.text = `${song} by ${artist}`;
 
   return attachment;
 }


### PR DESCRIPTION
## Summary
- Attach the 30-second `preview_url` from each Crucial Tracks feed item as a `MediaAttachment` with `mimeType: "audio"`, so Tapestry renders its inline audio player on the post.
- Set the attachment `text` to `"<song> by <artist>"` for an accessibility label on the player.
- Bump `cc.otavio.tracks.crucial` manifest `version` 4 → 5 so installed copies pick up the update.

## Test plan
- [x] `make cc.otavio.tracks.crucial.tapestry` builds without error
- [x] Install the new `.tapestry` on device and confirm each entry shows artwork plus a playable audio control
- [x] Tapping the audio control plays the 30-second preview
- [x] Entries without a `preview_url` still render with artwork only (no crash)