### PR TITLE
Show album artwork in Crucial Tracks audio player thumbnail

### DIFF
--- a/cc.otavio.tracks.crucial/plugin-config.json
+++ b/cc.otavio.tracks.crucial/plugin-config.json
@@ -8,5 +8,5 @@
   "site": "https://app.crucialtracks.org",
   "service_name": "Crucial Tracks",
   "item_style": "post",
-  "version": 5
+  "version": 6
 }

--- a/cc.otavio.tracks.crucial/plugin.js
+++ b/cc.otavio.tracks.crucial/plugin.js
@@ -80,15 +80,13 @@ function createItemFromEntry(entry) {
 
   const attachments = [];
 
-  if (songDetails.artwork_url) {
-    attachments.push(
-      createMediaAttachment(songDetails.artwork_url)
-    );
-  }
-
   if (songDetails.preview_url) {
     attachments.push(
       createAudioAttachment(songDetails.preview_url, songDetails)
+    );
+  } else if (songDetails.artwork_url) {
+    attachments.push(
+      createMediaAttachment(songDetails.artwork_url)
     );
   }
 
@@ -188,6 +186,10 @@ function createAudioAttachment(url, songDetails) {
 
   attachment.mimeType = "audio";
   attachment.text = `${song} by ${artist}`;
+
+  if (songDetails.artwork_url) {
+    attachment.thumbnail = songDetails.artwork_url;
+  }
 
   return attachment;
 }


### PR DESCRIPTION
## Summary
- Set `thumbnail` on the audio `MediaAttachment` to the track's `artwork_url`, so Tapestry shows the album cover in the player's square instead of the default waveform.
- When a `preview_url` is present, drop the standalone artwork attachment — the audio attachment already carries the artwork, avoiding a duplicate image in the timeline.
- Fallback: when there is no `preview_url`, still attach the artwork as a plain image so posts without a preview are not art-less.
- Bump `cc.otavio.tracks.crucial` manifest `version` 5 → 6.

## Test plan
- [x] `make cc.otavio.tracks.crucial.tapestry` builds cleanly
- [x] On device: entries with a preview show the album cover next to the play button
- [x] On device: entries without a preview still show the artwork as an image attachment